### PR TITLE
feat: middleware 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,41 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: '/user/:path*',
-        destination: `${process.env.API_URL}/auth/:path*`,
-      },
-      {
-        source: '/groups/:path*',
-        destination: `${process.env.API_URL}/groups/:path*`,
-      },
-      {
-        source: '/oauthApps',
-        destination: `${process.env.API_URL}/oauthApps`,
-      },
-      {
-        source: '/images',
-        destination: `${process.env.API_URL}/images`,
-      },
-      {
-        source: '/tasks/:path*',
-        destination: `${process.env.API_URL}/tasks/:path*`,
-      },
-      {
-        source: '/auth/:path*',
-        destination: `${process.env.API_URL}/auth/:path*`,
-      },
-      {
-        source: '/articles/:path*',
-        destination: `${process.env.API_URL}/articles/:path*`,
-      },
-      {
-        source: '/comments/:path*',
-        destination: `${process.env.API_URL}/comments/:path*`,
-      },
-    ];
-  },
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/src/app/(auth)/login/_utils/mutation.ts
+++ b/src/app/(auth)/login/_utils/mutation.ts
@@ -3,7 +3,7 @@
 import type { ILogin } from '../_types/login.interface';
 
 export const loginMutationFn = async (data: ILogin) => {
-  const res = await fetch('/auth/signIn', {
+  const res = await fetch('/api/auth/signIn', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/app/(auth)/signup/_utils/mutation.ts
+++ b/src/app/(auth)/signup/_utils/mutation.ts
@@ -4,7 +4,7 @@ import type { ISignup } from '../_types/signup.interface';
 import type { ILoginResponse } from '../../login/_types/login.interface';
 
 export const signUpMutationFn = async (data: ISignup) => {
-  const res = await fetch('/auth/signUp', {
+  const res = await fetch('/api/auth/signUp', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NotFoundPage = () => {
+  return <section>페이지 없음</section>;
+};
+
+export default NotFoundPage;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  try {
+    // env 확인
+    if (!process.env.API_URL) {
+      console.error('API_URL is not defined');
+
+      return NextResponse.next();
+    }
+
+    const { pathname } = request.nextUrl;
+
+    // API 요청 체크
+    if (pathname.startsWith('/api/')) {
+      const newPath = pathname.replace('/api/', '/'); // 임의로 붙인 api 글자 제거
+
+      // 새로운 요청 URL 생성
+      const apiUrl = new URL(`${process.env.API_URL}${newPath}`);
+
+      // rewrite 응답 생성
+      const response = NextResponse.rewrite(apiUrl);
+
+      // 기본 헤더 설정
+      response.headers.set('Content-Type', 'application/json');
+
+      return response;
+    }
+
+    return NextResponse.next();
+  } catch (error) {
+    console.error('[Middleware Error]', {
+      path: request.nextUrl.pathname,
+      error: error instanceof Error ? error.message : error,
+      timestamp: new Date().toISOString(),
+    });
+
+    return NextResponse.next();
+  }
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: [
+    '/api/:path*',
+    // 정적 리소스 제외
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|icons|fonts|images).*)',
+  ],
+};


### PR DESCRIPTION
## 📝 작업 내역

- next.config.js rewrites 제거 (client 에서만 작동하기에 제거 판단)
- middleware에서 rewrites 기능 추가 (server, client 모두 rewrite 가능)
- api 요청 시 접두사에 `/api` 글자 추가 (api 경로 그룹화)

## 📢 전달 사항

middleware 에서 api 요청에 대한 경로 그룹화를 위해 swagger에서 사용하는 api 경로 앞에 `/api`가 붙도록 했습니다.
접두사에 api로 그룹화 하면 페이지 경로와의 충돌도 없고 추후 해당 경로가 api인지에 대한 명확성도 생겨서 그룹화 하였습니다.
해당 사항 적절한지 논의 드립니다!