### PR TITLE
feat: 로그인/회원가입 에러 핸들링 및 버튼 상태 관리 개선

### DIFF
--- a/src/app/(auth)/_constants/validationPatterns.ts
+++ b/src/app/(auth)/_constants/validationPatterns.ts
@@ -2,4 +2,5 @@
 export const EMAIL_PATTERN = /\S+@\S+\.\S+/;
 
 // PASSWORD_PATTERN: 숫자, 영문, 특수문자(!@#$%^&*) 조합 확인
-export const PASSWORD_PATTERN = /^[a-zA-Z0-9!@#$%^&*]+$/;
+export const PASSWORD_PATTERN =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]+$/;

--- a/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/src/app/(auth)/login/_components/LoginForm.tsx
@@ -17,7 +17,7 @@ const LoginForm = ({ onSubmit }: ILoginSubmit) => {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<ILogin>({ mode: 'onChange' });
 
   const emailId = useId();
@@ -64,7 +64,7 @@ const LoginForm = ({ onSubmit }: ILoginSubmit) => {
           비밀번호를 잊으셨나요?
         </Link>
       </p>
-      <Button type='submit' className='mt-16 w-full'>
+      <Button type='submit' disabled={!isValid} className='mt-16 w-full'>
         로그인
       </Button>
     </form>

--- a/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/src/app/(auth)/login/_components/LoginForm.tsx
@@ -14,7 +14,7 @@ import FormControl from '@/components/form/FormControl';
 import FormLabel from '@/components/form/FormLabel';
 import Input from '@/components/input/Input';
 
-import type { ILogin } from '../_types/login.interface';
+import type { IErrorResponse, ILogin } from '../_types/login.interface';
 import { loginMutationFn } from '../_utils/mutation';
 import { EMAIL_PATTERN } from '../../_constants/validationPatterns';
 
@@ -26,6 +26,7 @@ const LoginForm = () => {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors, isValid },
   } = useForm<ILogin>({ mode: 'onChange' });
 
@@ -39,8 +40,14 @@ const LoginForm = () => {
       cookies.set('refreshToken', res.refreshToken);
       router.push('/');
     },
-    onError: (error) => {
+    onError: (error: IErrorResponse) => {
       console.error('Failed to login', error);
+
+      const errorKeys = Object.keys(error.details) as Array<
+        keyof typeof error.details
+      >;
+
+      setError(errorKeys[0], { message: error.message });
     },
   });
 

--- a/src/app/(auth)/login/_components/LoginSection.tsx
+++ b/src/app/(auth)/login/_components/LoginSection.tsx
@@ -1,39 +1,13 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import Cookies from 'universal-cookie';
-
-import type { ILogin } from '../_types/login.interface';
-import { loginMutationFn } from '../_utils/mutation';
 
 import LoginForm from './LoginForm';
 
-const cookies = new Cookies();
-
 const LoginSection = () => {
-  const router = useRouter();
-
-  const loginMutation = useMutation({
-    mutationFn: loginMutationFn,
-    onSuccess: (res) => {
-      cookies.set('accessToken', res.accessToken);
-      cookies.set('refreshToken', res.refreshToken);
-      router.push('/');
-    },
-    onError: (error) => {
-      console.error('Failed to login', error);
-    },
-  });
-
-  const handleLogin = (data: ILogin) => {
-    loginMutation.mutate(data);
-  };
-
   return (
     <div>
-      <LoginForm onSubmit={handleLogin} />
+      <LoginForm />
       <div className='my-[2.4rem] flex flex-wrap items-center justify-center gap-[1.2rem] sm:mb-[4.8rem]'>
         <p className='text-md font-medium leading-[1.2] text-text-primary sm:text-base sm:leading-[1.2]'>
           아직 계정이 없으신가요?

--- a/src/app/(auth)/login/_types/login.interface.ts
+++ b/src/app/(auth)/login/_types/login.interface.ts
@@ -16,3 +16,14 @@ export interface ILoginResponse {
   accessToken: string;
   refreshToken: string;
 }
+
+type ErrorKeys = 'email' | 'password';
+
+export interface IErrorResponse {
+  details: {
+    [key in ErrorKeys]: {
+      message: string;
+    };
+  };
+  message: string;
+}

--- a/src/app/(auth)/login/_types/login.interface.ts
+++ b/src/app/(auth)/login/_types/login.interface.ts
@@ -17,11 +17,9 @@ export interface ILoginResponse {
   refreshToken: string;
 }
 
-type ErrorKeys = 'email' | 'password';
-
 export interface IErrorResponse {
   details: {
-    [key in ErrorKeys]: {
+    [key in keyof ILogin]: {
       message: string;
     };
   };

--- a/src/app/(auth)/login/_types/login.interface.ts
+++ b/src/app/(auth)/login/_types/login.interface.ts
@@ -1,12 +1,6 @@
-import type { SubmitHandler } from 'react-hook-form';
-
 export interface ILogin {
   email: string;
   password: string;
-}
-
-export interface ILoginSubmit {
-  onSubmit: SubmitHandler<ILogin>;
 }
 
 export interface ILoginResponse {

--- a/src/app/(auth)/login/_utils/mutation.ts
+++ b/src/app/(auth)/login/_utils/mutation.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import type { ILogin, ILoginResponse } from '../_types/login.interface';
+import type {
+  IErrorResponse,
+  ILogin,
+  ILoginResponse,
+} from '../_types/login.interface';
 
 export const loginMutationFn = async (data: ILogin) => {
   const res = await fetch('/auth/signIn', {
@@ -11,11 +15,11 @@ export const loginMutationFn = async (data: ILogin) => {
     body: JSON.stringify(data),
   });
 
-  const result: ILoginResponse = await res.json();
+  const result = await res.json();
 
   if (!res.ok) {
-    throw result;
+    throw result as IErrorResponse;
   }
 
-  return result;
+  return result as ILoginResponse;
 };

--- a/src/app/(auth)/login/_utils/mutation.ts
+++ b/src/app/(auth)/login/_utils/mutation.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ILogin } from '../_types/login.interface';
+import type { ILogin, ILoginResponse } from '../_types/login.interface';
 
 export const loginMutationFn = async (data: ILogin) => {
   const res = await fetch('/auth/signIn', {
@@ -11,7 +11,7 @@ export const loginMutationFn = async (data: ILogin) => {
     body: JSON.stringify(data),
   });
 
-  const result = await res.json();
+  const result: ILoginResponse = await res.json();
 
   if (!res.ok) {
     throw result;

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -5,6 +5,7 @@ import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import Cookies from 'universal-cookie';
 
 import Button from '@/components/button/Button';
@@ -22,6 +23,7 @@ import {
 const cookies = new Cookies();
 
 const SignupForm = () => {
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -43,6 +45,10 @@ const SignupForm = () => {
     onSuccess: (res) => {
       cookies.set('accessToken', res.accessToken);
       cookies.set('refreshToken', res.refreshToken);
+      router.push('/');
+    },
+    onError: (error) => {
+      console.error('Failed to Sign Up', error);
     },
   });
 
@@ -136,7 +142,11 @@ const SignupForm = () => {
           />
         </FormControl>
       </div>
-      <Button type='submit' disabled={!isValid}>
+      <Button
+        type='submit'
+        disabled={!isValid}
+        isLoading={signUpMutation.isPending}
+      >
         회원가입
       </Button>
     </form>

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -13,7 +13,7 @@ import FormControl from '@/components/form/FormControl';
 import FormLabel from '@/components/form/FormLabel';
 import Input from '@/components/input/Input';
 
-import type { ISignup } from '../_types/signup.interface';
+import type { IErrorResponse, ISignup } from '../_types/signup.interface';
 import { signUpMutationFn } from '../_utils/mutation';
 import {
   EMAIL_PATTERN,
@@ -27,6 +27,7 @@ const SignupForm = () => {
   const {
     register,
     handleSubmit,
+    setError,
     watch,
     trigger,
     formState: { errors, isValid },
@@ -47,8 +48,14 @@ const SignupForm = () => {
       cookies.set('refreshToken', res.refreshToken);
       router.push('/');
     },
-    onError: (error) => {
+    onError: (error: IErrorResponse) => {
       console.error('Failed to Sign Up', error);
+
+      const errorKeys = Object.keys(error.details) as Array<
+        keyof typeof error.details
+      >;
+
+      setError(errorKeys[0], { message: error.message });
     },
   });
 

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -27,7 +27,7 @@ const SignupForm = () => {
     handleSubmit,
     watch,
     trigger,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<ISignup>({ mode: 'onChange' });
 
   const nicknameId = useId();
@@ -136,7 +136,9 @@ const SignupForm = () => {
           />
         </FormControl>
       </div>
-      <Button type='submit'>회원가입</Button>
+      <Button type='submit' disabled={!isValid}>
+        회원가입
+      </Button>
     </form>
   );
 };

--- a/src/app/(auth)/signup/_types/signup.interface.ts
+++ b/src/app/(auth)/signup/_types/signup.interface.ts
@@ -5,11 +5,9 @@ export interface ISignup {
   passwordConfirmation: string;
 }
 
-type ErrorKeys = 'email' | 'nickname' | 'password';
-
 export interface IErrorResponse {
   details: {
-    [key in ErrorKeys]: {
+    [key in keyof ISignup]: {
       message: string;
     };
   };

--- a/src/app/(auth)/signup/_types/signup.interface.ts
+++ b/src/app/(auth)/signup/_types/signup.interface.ts
@@ -4,3 +4,14 @@ export interface ISignup {
   password: string;
   passwordConfirmation: string;
 }
+
+type ErrorKeys = 'email' | 'nickname' | 'password';
+
+export interface IErrorResponse {
+  details: {
+    [key in ErrorKeys]: {
+      message: string;
+    };
+  };
+  message: string;
+}

--- a/src/app/(auth)/signup/_utils/mutation.ts
+++ b/src/app/(auth)/signup/_utils/mutation.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ISignup } from '../_types/signup.interface';
+import type { IErrorResponse, ISignup } from '../_types/signup.interface';
 import type { ILoginResponse } from '../../login/_types/login.interface';
 
 export const signUpMutationFn = async (data: ISignup) => {
@@ -12,11 +12,11 @@ export const signUpMutationFn = async (data: ISignup) => {
     body: JSON.stringify(data),
   });
 
-  const result: ILoginResponse = await res.json();
+  const result = await res.json();
 
   if (!res.ok) {
-    throw result;
+    throw result as IErrorResponse;
   }
 
-  return result;
+  return result as ILoginResponse;
 };

--- a/src/app/(auth)/signup/_utils/mutation.ts
+++ b/src/app/(auth)/signup/_utils/mutation.ts
@@ -14,5 +14,9 @@ export const signUpMutationFn = async (data: ISignup) => {
 
   const result: ILoginResponse = await res.json();
 
+  if (!res.ok) {
+    throw result;
+  }
+
   return result;
 };


### PR DESCRIPTION
## 📝 작업 내역

- 로그인 submit 함수 LoginForm 컴포넌트로 이동
- 로그인/회원가입 버튼 disabled, isLoading 적용
- 로그인/회원가입 error 발생시 input error 및 helperText 적용
- 비밀번호 정규표현식 수정 (영문, 숫자, 특수문자 최소 한개씩 들어가도록)

## ☑️ 의논 사항

- 버튼 loading 상태일 때 텍스트없이 로딩 이미지만 나타나는데, 텍스트와 로딩 이미지를 같이 배치하는 건 어떨까요?
- setError 할 때 key값 type 지정하는데 방법이 안떠올라서 어려웠습니다 ㅠ 혹시 쉽고 간단한 방법이 있다면 추천해주시면 감사드리겟습니당..!
